### PR TITLE
Add Windows run instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,11 @@ Running a flat world:
 cargo run --release -- -f
 ```
 
+### Running on Windows
+
+On windows-msvc, make sure that you have a version of ninja.exe ([download here](https://github.com/ninja-build/ninja/releases)) available in your PATH varaible.
+
+
 ### Controls
 
 - `awsd` to move around


### PR DESCRIPTION
As mentioned here: https://crates.io/crates/shaderc-sys
shaderc-sys needs ninja.exe to build from source 
on windows-msvc
This pull request adds that information in the README.md